### PR TITLE
Config, open port and other misc fixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,10 +47,11 @@ options:
     default: False
     type: boolean
     description: Turn on/off security
-  verbose:
-    default: False
-    type: boolean
-    description: Verbose logging output
+  #verbose:
+  # TODO: need to transform this into "v"'s for config
+    #default: False
+    #type: boolean
+    #description: Verbose logging output
   objcheck:
     default: False
     type: boolean
@@ -84,27 +85,25 @@ options:
     type: boolean
     description: Disable data file preallocation
   nssize:
-    default: "default"
     type: string
     description: Specify .ns file size for new databases
-  mms-token:
-    default: "disabled"
-    type: string
-    description: Accout token for Mongo monitoring server
-  mms-name:
-    default: "disabled"
-    type: string
-    description: Server name for Mongo monitoring server
-  mms-interval:
-    default: "disabled"
-    type: string
-    description: Ping interval for Mongo monitoring server ( in number of seconds )
+  # TODO: these mms-* options don't work on 2.6
+  #mms-token:
+    #default: "disabled"
+    #type: string
+    #description: Accout token for Mongo monitoring server
+  #mms-name:
+    #default: "disabled"
+    #type: string
+    #description: Server name for Mongo monitoring server
+  #mms-interval:
+    #default: "disabled"
+    #type: string
+    #description: Ping interval for Mongo monitoring server ( in number of seconds )
   oplogSize:
-    default: "default"
     type: string
     description: Custom size for replication operation log
   opIdMem:
-    default: "default"
     type: string
     description: Size limit for in-memory storage of op ids
   replicaset:

--- a/lib/charms/layer/mongodb.py
+++ b/lib/charms/layer/mongodb.py
@@ -9,7 +9,6 @@ from charmhelpers.fetch import (
     apt_install,
     apt_purge,
     apt_update,
-    _run_apt_command,
 )
 
 from charmhelpers.core.host import (
@@ -42,9 +41,9 @@ class MongoDB(object):
     config_options = ['dbpath', 'logpath', 'logappend', 'bind_ip', 'port',
                       'journal', 'cpu', 'auth', 'verbose', 'objcheck', 'quota',
                       'oplog', 'nocursors', 'nohints', 'noscripting',
-                      'notablescans', 'noprealloc', 'nssize', 'mms-token',
-                      'mms-name', 'mms-interval', 'oplogSize', 'opIdMem',
-                      'replicaset']
+                      'notablescans', 'noprealloc', 'nssize',
+                      #'mms-token', 'mms-name', 'mms-interval',
+                      'oplogSize', 'opIdMem', 'replicaset']
     config_map = {
         # JUJU CFG: MONGO CFG
         'replicaset': 'replSet',
@@ -61,11 +60,11 @@ class MongoDB(object):
 
     def uninstall(self):
         apt_purge(self.packages())
-        _run_apt_command(['apt-get', 'autoremove', '--purge', '--assume-yes'])
+        subprocess.check_call(['apt-get', 'autoremove', '--purge', '--assume-yes'])
 
     def configure(self, config):
         cfg = {self.config_map.get(k, k): v
-               for k, v in iter(config.items()) if k in self.config_options}
+               for k, v in iter(config.items()) if v and k in self.config_options}
         self._render_config(cfg)
 
     def packages(self):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,8 +25,6 @@ series:
 provides:
   database:
     interface: mongodb
-  benchmark:
-    interface: benchmark
-peers:
-  replica-set:
-    interface: mongodb
+#peers:
+  #replica-set:
+    #interface: mongodb

--- a/reactive/mongodb.py
+++ b/reactive/mongodb.py
@@ -1,6 +1,8 @@
 from charmhelpers.core.hookenv import (
     config,
     status_set,
+    open_port,
+    close_port,
 )
 
 from charmhelpers.core.host import service_restart
@@ -36,9 +38,15 @@ def install():
 @when('mongodb.installed')
 @when_not('mongodb.ready')
 def configure():
-    m = mongodb.mongodb(config().get('version'))
-    m.configure(config())
+    c = config()
+    m = mongodb.mongodb(c.get('version'))
+    m.configure(c)
     service_restart('mongodb')
+
+    if c.changed('port') and c.previous('port'):
+        close_port(c.previous('port'))
+    open_port(c['port'])
+
     set_state('mongodb.ready')
 
 

--- a/tests/test_lib_mongodb.py
+++ b/tests/test_lib_mongodb.py
@@ -129,7 +129,7 @@ class MongoDBTest(unittest.TestCase):
         mapt.assert_called_with(['foo=99.9', 'baz'])
 
     @patch('charms.layer.mongodb.apt_purge')
-    @patch('charms.layer.mongodb._run_apt_command')
+    @patch('subprocess.check_call')
     def test_uninstall(self, mrac, mapt):
         m = mongodb.MongoDB('dummy', '99.9')
         m.uninstall()

--- a/tests/test_reactive_mongodb.py
+++ b/tests/test_reactive_mongodb.py
@@ -20,7 +20,7 @@ class MockConfig(MagicMock):
 
 
 class ReactiveTestCase(unittest.TestCase):
-    patches = ['set_state', 'config', 'remove_state', 'status_set']
+    patches = ['set_state', 'config', 'remove_state', 'status_set', 'open_port']
     callables = {'config': MockConfig}
 
     def setUp(self):


### PR DESCRIPTION
Comment out config options and that were invalid on Mongo 2.6
Remove defaults that were invalid config for Mongo 2.6
Open the configured mongo port.
Remove unimplemented benchmark endpoint.
Comment out unimplemented peers endpoint (interface doesn't support it
yet).